### PR TITLE
Fix: adjust bachelor line spacing, title spacing and full space repla…

### DIFF
--- a/lib/format.typ
+++ b/lib/format.typ
@@ -28,8 +28,8 @@
     spacing: 12pt,
   ),
   bachelor: (
-    leading: 11pt,
-    spacing: 11pt,
+    leading: 12pt,
+    spacing: 12pt,
   ),
 )
 
@@ -44,7 +44,7 @@
     below: (16pt, 0pt, 0pt),
   ),
   bachelor: (
-    above: (16pt, 0pt, 0pt),
+    above: (32pt, 0pt, 0pt),
     below: (16pt, 2pt, 0pt),
   ),
 )

--- a/lib/layouts/appendix.typ
+++ b/lib/layouts/appendix.typ
@@ -9,7 +9,7 @@
   let appendix-label = if english-writing {
     "Appendix "
   } else if not graduate {
-    "附 录"
+    [附#h(0.7em)录]
   } else {
     "附录"
   }

--- a/lib/pages/abstract.typ
+++ b/lib/pages/abstract.typ
@@ -9,7 +9,7 @@
   keyword-weight: "regular",
   keyword-sep: "；",
   keyword-indent: true,
-  outline-title: "摘　要",
+  outline-title: [摘#h(0.7em)要],
   title: none,
   outlined: true,
   funding: none,

--- a/lib/pages/outline.typ
+++ b/lib/pages/outline.typ
@@ -1,6 +1,6 @@
 // 目录页
 #let outline-page(
-  title: "目　录",
+  title: [目#h(0.7em)录],
   indent: (0pt, 24pt, 24pt),
   weight: none,
   fill: (repeat([.], gap: 0.15em),),
@@ -35,7 +35,11 @@
             let inner = {
               if entry.prefix() not in (none, []) {
                 entry.prefix()
-                h(0.3em)
+                if entry.level == 1 and repr(entry.prefix()).contains("章") {
+                  h(-0.1em)
+                } else {
+                  h(0.3em)
+                }
               }
               if entry.element.body == [*Abstract*] { [ABSTRACT] } else { entry.body() }
             }

--- a/lib/template.typ
+++ b/lib/template.typ
@@ -138,7 +138,7 @@
         } else if graduate {
           [第 #nums.at(0) 章#h(0.7em)]
         } else {
-          [第#chinese-chapter-number(nums.at(0))章　]
+          [第#chinese-chapter-number(nums.at(0))章#h(0.7em)]
         }
       } else if nums.len() <= 3 {
         numbering("1.1", ..nums)
@@ -160,7 +160,7 @@
           keyword-label: "关键词",
           keyword-sep: "，",
           keyword-indent: false,
-          outline-title: "摘 要",
+          outline-title: [摘#h(0.7em)要],
           outlined: false,
           funding: none,
         )[#abstract]
@@ -193,10 +193,10 @@
     }
 
     #if graduate {
-      outline-page(title: if english-writing { "Contents" } else { "目　录" })
+      outline-page(title: if english-writing { "Contents" } else { [目#h(0.7em)录] })
     } else {
       outline-page(
-        title: if english-writing { "Contents" } else { "目 录" },
+        title: if english-writing { "Contents" } else { [目#h(0.7em)录] },
         indent: (0pt, 24pt, 18pt),
         weight: ("bold", "regular", "regular"),
         fill: (repeat([#move(dy: -0.1em, text(size: 0.4em)[·])], gap: -0.1em),),
@@ -237,7 +237,7 @@
     }
 
     if acknowledgement != none {
-      backmatter-page(title: if english-writing { "Acknowledgements" } else { "致　谢" })[#acknowledgement]
+      backmatter-page(title: if english-writing { "Acknowledgements" } else { [致#h(0.7em)谢] })[#acknowledgement]
     }
 
     if academic-achievements != none {
@@ -251,7 +251,7 @@
     }
   } else {
     if acknowledgement != none {
-      backmatter-page(title: if english-writing { "Acknowledgements" } else { "致 谢" })[#acknowledgement]
+      backmatter-page(title: if english-writing { "Acknowledgements" } else { [致#h(0.7em)谢] })[#acknowledgement]
     }
 
     if design_summary != none {


### PR DESCRIPTION
1. 改动范围

  - 行距调整：本科生（bachelor）正文原 leading/spacing 为 11pt，导致行间距偏紧，与学校 Word 模板视觉效果不一致，调整为  12pt 使其更接近参考模板。
  - 一级标题前间距加倍：学校要求"第一章"、"摘要"、"参考文献"、"致谢"等一级标题前需空两行，因此将 heading-format.bachelor.above 从 16pt 翻倍为 32pt。
  - 全角空格替换为 #h(0.7em)：多处使用了全角空格（U+3000，如 "摘　要"、"目　录"、"致　谢"、"附 录"），统一替换为 #h(0.7em) 后，导出 PDF 的间距与 Word 版本更匹配。
  - 目录中"第一章"缩进叠加修复：正文"第一章"后的 #h(0.7em) 间距在目录中会与目录自身缩进叠加，导致目录条目位置偏右。在  outline.typ 中对含"章"字的一级条目使用 h(-0.1em) 抵消多余间距。

2. 影响范围

  | 文件 | 改动内容 |
  |---|---|
  | `lib/format.typ` | bachelor 的 `leading/spacing` 11pt→12pt；`above` 16pt→32pt |
  | `lib/template.typ` | 7 处全角空格替换为 `#h(0.7em)`（章节编号、摘要标题、目录标题、致谢标题） |
  | `lib/pages/outline.typ` | 目录标题全角空格替换 + 一级"章"条目缩进修正 |
  | `lib/pages/abstract.typ` | 摘要页面 `outline-title` 全角空格替换 |
  | `lib/layouts/appendix.typ` | 附录标签全角空格替换 |

  注意：研究生（graduate）模板中目录标题和致谢标题同样做了全角空格替换，但 leading/spacing 和 heading-above
  保持不变，不影响研究生模板排版。

3. 视觉效果

  - 本科生正文行距略微增大；
  - 一级标题前空两行（符合本科生格式要求）；
  - "摘 要"、"目 录"、"致 谢"、"附 录"中的字间间距从全角空格宽度变为 0.7em，视觉上与 word 版本更相符；
  - 目录中一级章节条目位置修正；